### PR TITLE
Feat: Add token input for GitHub API access during tests

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -53,6 +53,7 @@ jobs:
           python_version: ${{ env.python_version }}
           path_prefix: "test-python-project"
           tests_path: "tests"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Perform Python project failing tests
       - name: "Run action: ${{ github.repository }} [Test Failure]"
@@ -64,6 +65,7 @@ jobs:
           # Test permit failure using action input
           tests_path: "tests_fail"
           permit_fail: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Perform Python project failing tests
       - name: "Run action: ${{ github.repository }} [Test Failure]"
@@ -76,6 +78,7 @@ jobs:
           report_artefact: false
           # Test permit failure using action input
           tests_path: "tests_fail"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Validate previous step failure"
         if: steps.tests-fail.outcome == 'success'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The example below demonstrates an implementation as a matrix job:
         with:
           python_version: ${{ matrix.python-version }}
           report_artefact: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 Note: build your project before invoking tests (not shown above)
@@ -57,6 +58,7 @@ Note: build your project before invoking tests (not shown above)
 | tests_path      | False    | test/tests   | Path relative to the project folder containing tests |
 | tox_tests       | False    | False        | Uses tox to perform Python tests (requires tox.ini)  |
 | tox_envs        | False    | "lint tests" | Space separated list of tox environment names to run |
+| github_token    | False    |              | GitHub token for API access during tests             |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -64,3 +66,21 @@ Note: build your project before invoking tests (not shown above)
 
 The embedded pytest behaviour will create HTML coverage reports as ZIP file
 bundles. Set REPORT_ARTEFACT true to also upload them to GitHub as artefacts.
+
+## GitHub Token Support
+
+The action accepts an optional `github_token` input parameter that makes the
+GitHub token available to your tests as the `GITHUB_TOKEN` environment variable.
+This is useful for tests that need to interact with GitHub APIs or access
+private repositories without encountering rate limits.
+
+### Example with GitHub Token
+
+```yaml
+- name: "Test Python project with GitHub API access"
+  uses: lfreleng-actions/python-test-action@main
+  with:
+    python_version: "3.12"
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    report_artefact: true
+```

--- a/action.yaml
+++ b/action.yaml
@@ -42,12 +42,18 @@ inputs:
     description: 'Space separated list of tox environments to run'
     required: false
     # type: string
+  github_token:
+    description: 'GitHub token for API access during tests'
+    required: false
+    # type: string
 
 runs:
   using: 'composite'
   steps:
     - name: 'Setup action/environment'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         # Setup action/environment
         if [ -z "${{ inputs.python_version }}" ]; then
@@ -170,6 +176,8 @@ runs:
     - name: 'Performing tests [tox]'
       if: steps.tox-config.outputs.type == 'file' && inputs.tox_tests == 'true'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         # Performing tests [tox]
         echo 'Installing: tox ⬇️'
@@ -194,6 +202,8 @@ runs:
     - name: 'Install project and test/dev dependencies [pytest]'
       if: inputs.tox_tests != 'true'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         # Install project and test/dev dependencies
 
@@ -226,6 +236,8 @@ runs:
     - name: 'Run tests and coverage report [pytest]'
       if: inputs.tox_tests != 'true'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         # Tests and coverage report [pytest]
 


### PR DESCRIPTION
This is necessary to support tests that query the GitHub APIs. Authenticated access prevents rate-limiting and test failures.