### PR TITLE
Fix: Install setup.py/setup.cfg before requirements

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -638,6 +638,8 @@ runs:
         # subprojects do not collide on the same cache key.
         cache-dependency-glob: |
           ${{ inputs.path_prefix }}/pyproject.toml
+          ${{ inputs.path_prefix }}/setup.py
+          ${{ inputs.path_prefix }}/setup.cfg
           ${{ inputs.path_prefix }}/requirements*.txt
           ${{ inputs.path_prefix }}/uv.lock
           ${{ inputs.path_prefix }}/tox.ini
@@ -841,6 +843,28 @@ runs:
         # (editable or not) before the test runners so that the latest
         # local code is what test imports resolve against.
         #
+        # Precedence (first match wins):
+        #   1. pyproject.toml         -> install ./<prefix>[test,dev]
+        #      (with graceful fallback to [test], then bare).
+        #   2. setup.py / setup.cfg   -> install ./<prefix>, and ALSO
+        #      install requirements.txt if present alongside. The
+        #      canonical pbr layout ships both: setup.py invokes pbr
+        #      and requirements.txt holds the deps. Layering
+        #      requirements.txt on top is a no-op for projects that
+        #      already pull it in via install_requires, and rescues
+        #      hand-rolled setup.py projects that do not.
+        #   3. requirements.txt only  -> pure-deps project, no
+        #      installable package; tests cannot import a project
+        #      module.
+        #   4. none of the above      -> warn and skip install.
+        #
+        # The legacy ordering placed requirements.txt above
+        # setup.py / setup.cfg, which made the legacy branch
+        # unreachable for any project shipping both files (e.g. pbr).
+        # That installed dependencies but never the project itself,
+        # causing pytest to fail with ModuleNotFoundError on import
+        # of the project package.
+        #
         # We deliberately do NOT pass '--system' here. setup-uv has
         # already provisioned and activated a venv at .venv (PATH is
         # prepended, VIRTUAL_ENV is exported), so an unqualified
@@ -877,10 +901,6 @@ runs:
             uv pip install ${UV_EDITABLE_FLAG} \
               "./${path_prefix_input}"
           fi
-        elif [ -f "$path_prefix_input/requirements.txt" ]; then
-          echo "Source: $path_prefix_input/requirements.txt ⬇️"
-          uv pip install \
-            -r "$path_prefix_input/requirements.txt"
         elif [ -f "$path_prefix_input/setup.py" ] || \
              [ -f "$path_prefix_input/setup.cfg" ]; then
           # Legacy setuptools-style projects without pyproject.toml.
@@ -888,6 +908,13 @@ runs:
           # any 'tests/conftest.py' that imports from the package work
           # at test time. uv accepts the same './<prefix>' form here
           # as for pyproject-based projects.
+          #
+          # If a requirements.txt is present alongside, layer it on
+          # top after the local install. For pbr projects this is a
+          # no-op (deps already pulled in via install_requires); for
+          # hand-rolled setup.py projects that ship a requirements.txt
+          # but do not reference it from setup.py this ensures their
+          # extra runtime deps are available at test time.
           if [ -f "$path_prefix_input/setup.py" ]; then
             echo "Source: $path_prefix_input/setup.py ⬇️"
           else
@@ -895,9 +922,23 @@ runs:
           fi
           uv pip install ${UV_EDITABLE_FLAG} \
             "./${path_prefix_input}"
+          if [ -f "$path_prefix_input/requirements.txt" ]; then
+            echo "Also installing:" \
+              "$path_prefix_input/requirements.txt ⬇️"
+            uv pip install \
+              -r "$path_prefix_input/requirements.txt"
+          fi
+        elif [ -f "$path_prefix_input/requirements.txt" ]; then
+          # Pure-deps project (no installable package). Tests run
+          # against whatever is in requirements.txt only; imports of
+          # a project module will fail. This is the documented
+          # behaviour for this branch.
+          echo "Source: $path_prefix_input/requirements.txt ⬇️"
+          uv pip install \
+            -r "$path_prefix_input/requirements.txt"
         else
-          echo 'Warning: no pyproject.toml, requirements.txt,' \
-            'setup.py or setup.cfg found under' \
+          echo 'Warning: no pyproject.toml, setup.py, setup.cfg or' \
+            'requirements.txt found under' \
             "'$path_prefix_input' ⚠️"
           echo 'Skipping project install; tests will run against' \
             'pytest tooling only - imports of the project package' \


### PR DESCRIPTION
## Motivation

The `Install project and test/dev dependencies [pytest]` step in
`action.yaml` previously evaluated its install conditional in this
order:

1. `pyproject.toml`
2. `requirements.txt`
3. `setup.py` / `setup.cfg`

Any project that ships **both** `setup.py`/`setup.cfg` *and*
`requirements.txt` falls into branch (2) and never reaches branch (3).
The legacy branch is therefore unreachable for the canonical
[pbr](https://docs.openstack.org/pbr/latest/) layout, which is
exactly that combination: `setup.py` invokes pbr, dependencies live
in `requirements.txt`, and `setup.py`'s
`install_requires=open("requirements.txt").read().splitlines()`
plumbs them through.

The result is that `uv pip install -r requirements.txt` installs
Sphinx / pytest plugins / etc. but **never installs the project
itself**, and pytest then fails at collection / import time with:

```
ModuleNotFoundError: No module named '<project>'
```

Failing run that motivated this fix:
https://github.com/lfit/releng-docs-conf/actions/runs/25217124950

```
Source: ./requirements.txt ⬇️
…
ERROR tests/test_simple.py::test_config -
  ModuleNotFoundError: No module named 'docs_conf'
```

## Fix

Reorder the conditional so `setup.py` / `setup.cfg` take precedence
over a bare `requirements.txt`. New precedence:

1. `pyproject.toml` → `uv pip install ./<prefix>[test,dev]` (with
   graceful fallback to `[test]`, then bare).
2. `setup.py` / `setup.cfg` → `uv pip install ./<prefix>`, **and
   also** `uv pip install -r requirements.txt` if one is present
   alongside. No-op for pbr projects (deps already pulled in via
   `install_requires`), but rescues hand-rolled `setup.py` projects
   that ship `requirements.txt` without referencing it from
   `install_requires`.
3. `requirements.txt` only → pure-deps project; no installable
   package; tests cannot import a project module.
4. None of the above → warn and skip install.

### Before

```bash
if   [ -f pyproject.toml ];   then  uv pip install "./<prefix>[test,dev]" → [test] → bare
elif [ -f requirements.txt ]; then  uv pip install -r requirements.txt          # ← deps only
elif [ -f setup.py ] || [ -f setup.cfg ]; then  uv pip install "./<prefix>"
fi
```

### After

```bash
if   [ -f pyproject.toml ];   then  uv pip install "./<prefix>[test,dev]" → [test] → bare
elif [ -f setup.py ] || [ -f setup.cfg ]; then
    uv pip install "./<prefix>"
    [ -f requirements.txt ] && uv pip install -r requirements.txt   # layered on top
elif [ -f requirements.txt ]; then  uv pip install -r requirements.txt
fi
```

## Drive-by

Extended the `setup-uv` `cache-dependency-glob` with `setup.py` and
`setup.cfg` so cache invalidation triggers when those files change
too.

## Deferred

- No `legacy-pbr` fixture added in this PR. The fixture wiring (new
  workflow job, fixture tree, README) would balloon the scope. Left
  as a TODO follow-up; the precedence reorder is the priority.

## Notes for reviewers

- Single commit, signed (GPG) and DCO-signed-off.
- Pre-commit clean (`pre-commit run --all-files`).
- All existing comments preserved and restructured; lead "Package
  installation order matters" comment rewritten to spell out the new
  precedence and the bug it fixes.
