### PR TITLE
Feat(coverage): Warn when omit excludes install location

### DIFF
--- a/.fixtures/README.md
+++ b/.fixtures/README.md
@@ -22,6 +22,17 @@ Both assertions are needed because the regression tracked in
 [issue #138][issue138] manifested as "tests pass, but coverage is 0%" -
 silent and easy to miss without a coverage-value check.
 
+A companion job, [`coverage-omit-warning`][ci], exercises the
+[`omit-excludes-install`](./omit-excludes-install/) fixture
+separately: the misconfiguration it ships cannot be rescued by the
+action (the omit list excludes the install location no matter what
+flags pytest gets), so the invariant being checked is that the
+action surfaces a clear warning to `$GITHUB_STEP_SUMMARY` rather
+than that coverage is non-zero. The unit-test job
+[`detect-coverage-unit-tests`][ci] runs the script directly
+against all fixtures plus a set of synthetic edge cases for fast
+feedback on detection-logic changes.
+
 [ci]: ../.github/workflows/testing.yaml
 [issue138]: https://github.com/lfreleng-actions/python-test-action/issues/138
 
@@ -40,8 +51,8 @@ action repository.
 
 ## The decision matrix
 
-The detection logic in `action.yaml` answers two independent
-questions about every consumer project:
+The detection logic in `scripts/detect_coverage.py` answers three
+independent questions about every consumer project:
 
 - **`cov_in_addopts`** - does any pytest config file
   (`pyproject.toml` `addopts`, `pytest.ini`, `setup.cfg`, `tox.ini`)
@@ -49,13 +60,18 @@ questions about every consumer project:
 - **`coverage_source_configured`** - does the discovered coverage
   config set a non-empty `[tool.coverage.run].source` /
   `[coverage:run] source` / `[run] source`?
+- **`coverage_omit_excludes_install`** - does the discovered
+  coverage config's `omit` list contain a glob whose pattern would
+  match the non-editable install location
+  (`.venv/lib/pythonX.Y/site-packages/<pkg>/`)?
 
 Each signal drives a different decision:
 
-| Signal                       | Decision it drives                                                  |
-|---                           |---                                                                  |
-| `cov_in_addopts`             | Whether the action injects `--cov` itself                           |
-| `coverage_source_configured` | Whether the action emits the "no coverage target configured" warning AND whether the action derives a fallback package name |
+| Signal                            | Decision it drives                                                  |
+|---                                |---                                                                  |
+| `cov_in_addopts`                  | Whether the action injects `--cov` itself                           |
+| `coverage_source_configured`      | Whether the action emits the "no coverage target configured" warning AND whether the action derives a fallback package name |
+| `coverage_omit_excludes_install`  | Whether the action emits the "omit excludes install location" warning (independent of the above; can fire alongside a fully-configured target) |
 
 When `cov_in_addopts=false` (the action will inject `--cov`), the
 form of the injection depends on `coverage_source_configured`:
@@ -70,12 +86,13 @@ form of the injection depends on `coverage_source_configured`:
 
 ## The fixtures
 
-| Fixture                                                  | Layout | `addopts` | `[tool.coverage.run].source` | Action's `--cov` decision |
-|---                                                       |---     |---        |---                           |---                        |
-| [`src-layout-path-source`](./src-layout-path-source/)    | src/   | `--cov=mypkg` | `["src"]`                | NO injection (addopts wins)         |
-| [`src-layout-pkg-source`](./src-layout-pkg-source/)      | src/   | (none)        | `["mypkg"]`              | inject bare `--cov` (source scopes) |
-| [`flat-layout-no-config`](./flat-layout-no-config/)      | flat   | (none)        | (none)                   | inject `--cov=mypkg` (derived)      |
-| [`addopts-cov-only`](./addopts-cov-only/)                | src/   | `--cov=mypkg` | (none)                   | NO injection (addopts wins)         |
+| Fixture                                                  | Layout | `addopts` | `[tool.coverage.run].source` | `[tool.coverage.run].omit` | Action's `--cov` decision           | Warning emitted                          |
+|---                                                       |---     |---        |---                           |---                         |---                                  |---                                       |
+| [`src-layout-path-source`](./src-layout-path-source/)    | src/   | `--cov=mypkg` | `["src"]`                | (clean)                    | NO injection (addopts wins)         | (none)                                   |
+| [`src-layout-pkg-source`](./src-layout-pkg-source/)      | src/   | (none)        | `["mypkg"]`              | (clean)                    | inject bare `--cov` (source scopes) | (none)                                   |
+| [`flat-layout-no-config`](./flat-layout-no-config/)      | flat   | (none)        | (none)                   | (none)                     | inject `--cov=mypkg` (derived)      | "no coverage target configured"          |
+| [`addopts-cov-only`](./addopts-cov-only/)                | src/   | `--cov=mypkg` | (none)                   | (none)                     | NO injection (addopts wins)         | (none)                                   |
+| [`omit-excludes-install`](./omit-excludes-install/)      | src/   | `--cov=mypkg` | `["mypkg"]`              | `["*/.venv/*", "*/tests/*"]` | NO injection (addopts wins)         | "omit excludes install location"         |
 
 ### Why each fixture matters
 
@@ -111,6 +128,26 @@ form of the injection depends on `coverage_source_configured`:
   as `src-layout-path-source` reappears via a different signal).
   The regex deliberately excludes `--cov-report` / `--cov-config` /
   `--cov-fail-under` to avoid false positives.
+
+- **`omit-excludes-install`** mirrors the regression tracked in
+  [`lfreleng-actions/markdown-table-fixer#129`][mtf129] and several
+  sibling consumer PRs. The `source` is the recommended import
+  name and addopts already has `--cov=mypkg`, but `omit` contains
+  `*/.venv/*` - which matches the directory the action's
+  non-editable install puts the package in
+  (`.venv/lib/pythonX.Y/site-packages/mypkg/`). coverage.py
+  honours the omit list and silently masks every measured file,
+  yielding 0% coverage even though `source` and addopts are
+  otherwise correct. The action cannot mechanically fix the
+  consumer's omit list (that would be overreach into project
+  configuration), but `detect_coverage.py` flags the pattern and
+  the action emits a step-summary warning naming the offending
+  glob(s) and the remediation. The `coverage-omit-warning` CI job
+  asserts both the warning text and that the bug IS still
+  reproduced (coverage XML reports 0%), so a future change that
+  silently "fixed" the omit handling would surface here too.
+
+[mtf129]: https://github.com/lfreleng-actions/markdown-table-fixer/pull/129
 
 ## Running fixtures locally
 

--- a/.fixtures/omit-excludes-install/pyproject.toml
+++ b/.fixtures/omit-excludes-install/pyproject.toml
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Fixture: omit-excludes-install
+#
+# Mirrors the regression seen in
+# lfreleng-actions/markdown-table-fixer (PR #129) and several other
+# downstream consumers: the package-name source is correct, but the
+# omit list excludes the very directory where a non-editable install
+# lives, so coverage refuses to instrument any of the project's
+# files and reports 0% despite all tests passing.
+#
+# Two omit globs cause this:
+#
+#   - '*/venv/*' and '*/.venv/*' match the venv created by setup-uv
+#     under the workspace root (the action's default install layout).
+#   - '*/site-packages/*' is even more aggressive: it excludes the
+#     install location anywhere on disk.
+#
+# The action cannot mechanically fix the consumer's omit list - that
+# would be overreach into project configuration - but it CAN detect
+# the pattern and emit a clear warning that pinpoints the offending
+# entries and the remediation. This fixture exercises that warning
+# path.
+
+[build-system]
+requires = ["hatchling>=1.24"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mypkg"
+version = "0.0.0"
+description = "Coverage fixture: omit excludes the install location"
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "pytest-cov>=5.0",
+  "coverage[toml]>=7.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mypkg"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# '--cov=mypkg' on the CLI scopes pytest-cov collection by import
+# name, so this alone is not the failure cause. The failure comes
+# entirely from the omit list below masking everything coverage.py
+# would otherwise have measured.
+addopts = ["-v", "--cov=mypkg"]
+
+[tool.coverage.run]
+# Source is correctly the import name. The pyproject.toml in the
+# original regression had a path-based source ('src/mypkg') AS WELL,
+# but here we isolate the omit-only failure mode so the assertion
+# is unambiguous.
+source = ["mypkg"]
+omit = [
+  "*/tests/*",
+  # The venv pattern is the bug. setup-uv creates the venv at
+  # '.venv' under the workspace root, so a non-editable install
+  # puts the package at '.venv/lib/pythonX.Y/site-packages/mypkg'.
+  # This omit glob matches that path component-by-component and
+  # silently excludes every measured file.
+  "*/.venv/*",
+]
+
+[tool.coverage.report]
+show_missing = true

--- a/.fixtures/omit-excludes-install/src/mypkg/__init__.py
+++ b/.fixtures/omit-excludes-install/src/mypkg/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Trivial fixture package used to exercise coverage collection."""
+
+
+def add(a: int, b: int) -> int:
+    """Return the sum of two integers."""
+    return a + b
+
+
+def multiply(a: int, b: int) -> int:
+    """Return the product of two integers."""
+    return a * b

--- a/.fixtures/omit-excludes-install/tests/test_mypkg.py
+++ b/.fixtures/omit-excludes-install/tests/test_mypkg.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the mypkg fixture package."""
+
+from mypkg import add, multiply
+
+
+def test_add() -> None:
+    assert add(2, 3) == 5
+
+
+def test_multiply() -> None:
+    assert multiply(4, 5) == 20

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -263,6 +263,249 @@ jobs:
           print(f'OK: {fixture} reported non-zero coverage ✅')
           PY
 
+  ### detect_coverage.py unit test suite ###
+  #
+  # The detection logic that decides whether to inject '--cov', what
+  # fallback package name to derive, and (since issue #138 follow-up)
+  # whether the consumer's omit list excludes the install location
+  # lives in 'scripts/detect_coverage.py'. The 'coverage-fixtures'
+  # job above exercises each shape end-to-end by running the entire
+  # action, but that path is expensive (per-fixture venv, real pytest,
+  # XML parse) and slow to iterate on. The unit-test job below runs
+  # the same script against the same fixtures plus a handful of
+  # synthetic edge cases in well under a second, catching detection
+  # regressions long before they could ship through the matrix job.
+  detect-coverage-unit-tests:
+    name: "detect_coverage.py unit tests"
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: 'audit'
+
+      - name: "Checkout repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Use the same uv-managed interpreter the action itself uses
+      # in production. Pinning to env.python_version keeps the unit
+      # tests on the same Python the rest of this workflow runs
+      # against; the script must work under 3.10-3.14 (and the
+      # tomllib/tomli fallback for the latter) but a single version
+      # is enough to catch logic regressions here - the matrix job
+      # is what guarantees runtime coverage across the version grid.
+      #
+      # 'activate-environment: true' tells setup-uv to create a
+      # venv at .venv/ under the workspace and prepend its bin/
+      # to PATH (also exporting VIRTUAL_ENV). We need that here
+      # because Ubuntu 24.04's system Python is PEP-668
+      # externally-managed, so 'uv pip install --system' refuses
+      # to install pytest. With the venv active, an unqualified
+      # 'uv pip install' targets the venv's interpreter and 'python
+      # -m pytest' resolves to the same one.
+      - name: "Set up uv"
+        # yamllint disable-line rule:line-length
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v7.2.0
+        with:
+          python-version: ${{ env.python_version }}
+          activate-environment: true
+          enable-cache: true
+
+      - name: "Install pytest"
+        shell: bash
+        run: |
+          # Install pytest into the uv-activated venv so 'python
+          # -m pytest' below resolves to the same interpreter.
+          uv pip install pytest
+
+      - name: "Run detect_coverage.py unit tests"
+        shell: bash
+        run: |
+          # The tests live under tests/ at the repo root; the test
+          # module prepends scripts/ to sys.path so it can import
+          # detect_coverage directly. Run via 'python -m pytest' to
+          # keep import resolution consistent with how the action
+          # itself invokes the script.
+          python -m pytest tests/test_detect_coverage.py -v
+
+  ### Coverage 'omit excludes install' warning fixture ###
+  #
+  # The 'omit-excludes-install' fixture is structurally different
+  # from the four cells in the coverage-fixtures matrix: it ships a
+  # config that the action cannot rescue (the broken omit list masks
+  # all measurement no matter what flags are passed), so the
+  # invariant being checked is the WARNING, not the coverage value.
+  #
+  # The action emits the warning to console AND to
+  # $GITHUB_STEP_SUMMARY, but $GITHUB_STEP_SUMMARY is a per-step
+  # file (each step gets a fresh path; the runner concatenates them
+  # at job-end into the published summary), so a follow-up
+  # assertion step cannot read what an earlier step wrote there.
+  # We therefore verify the warning channel via two surfaces that
+  # DO survive across steps:
+  #
+  #   1. The KEY=VALUE pairs the action wrote to $GITHUB_ENV in
+  #      the 'Detect coverage configuration' step
+  #      ('coverage_omit_excludes_install',
+  #      'coverage_problematic_omit_patterns'). If those are set
+  #      correctly it proves the bash template reached the warning
+  #      branch without crashing on a quoting accident.
+  #   2. The generated coverage.xml's 'line-rate' attribute, which
+  #      must be exactly 0.0 for this fixture's pyproject.toml (it
+  #      reproduces the bug). A future change that silently 'fixed'
+  #      omit handling would also be caught here.
+  #
+  # The exact rendered markdown that goes into the step summary is
+  # covered by the detect_coverage.py unit tests above (which check
+  # the KEY=VALUE contract verbatim) and by manual inspection of
+  # the per-job summary published in the GitHub UI.
+  #
+  # We intentionally leave coverage's '--cov-fail-under' unset in the
+  # fixture's pyproject.toml so that 0% coverage does NOT fail the
+  # action's pytest step - otherwise we'd be testing the failure
+  # mode rather than the warning channel.
+  coverage-omit-warning:
+    name: "coverage-omit-warning fixture"
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 8
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: 'audit'
+
+      - name: "Checkout repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Run the action against the omit fixture. editable left at
+      # its default 'false' - that is the install layout that
+      # triggers the regression in real consumers, and the warning
+      # only fires for non-editable installs.
+      - name: "Run action against fixture: omit-excludes-install"
+        uses: ./
+        with:
+          python_version: ${{ env.python_version }}
+          path_prefix: ".fixtures/omit-excludes-install"
+          tests_path: "tests"
+          # yamllint disable-line rule:line-length
+          artefact_name: "coverage-omit-warning-coverage"
+          report_artefact: "true"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Assert the detection step set the omit signals correctly.
+      # These env vars survive across steps because the action
+      # writes them via $GITHUB_ENV. Reaching the assertion below
+      # with the booleans flipped (or the patterns string empty)
+      # would mean either detect_coverage.py regressed or the
+      # action's bash failed to forward them - either is a hard
+      # fail.
+      - name: "Assert omit detection signals propagated to env"
+        shell: bash
+        run: |
+          # Verify env vars from the action's detection step
+          set -euo pipefail
+
+          echo "coverage_omit_excludes_install=" \
+            "${coverage_omit_excludes_install:-<unset>}"
+          echo "coverage_problematic_omit_patterns=" \
+            "${coverage_problematic_omit_patterns:-<unset>}"
+
+          if [ "${coverage_omit_excludes_install:-false}" != "true" ]; then
+            echo "Error: coverage_omit_excludes_install was not 'true' ❌" >&2
+            echo "The action's detect_coverage.py step did not flag" >&2
+            echo "the fixture's '*/.venv/*' omit entry." >&2
+            exit 1
+          fi
+
+          # The fixture sets exactly one offending pattern; assert
+          # both that the variable is non-empty and that the
+          # specific pattern is present. ';' is the documented
+          # separator (see scripts/detect_coverage.py main()).
+          if [ -z "${coverage_problematic_omit_patterns:-}" ]; then
+            echo "Error: coverage_problematic_omit_patterns is empty ❌" >&2
+            exit 1
+          fi
+          case ";${coverage_problematic_omit_patterns};" in
+            *";*/.venv/*;"*)
+              ;;
+            *)
+              echo "Error: '*/.venv/*' missing from patterns ❌" >&2
+              echo "Got: ${coverage_problematic_omit_patterns}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "OK: omit signals propagated correctly ✅"
+
+      # Reproducing the bug is the whole point of this fixture, so
+      # assert that the action did NOT manage to collect coverage.
+      # If a future change to the action somehow caused omit
+      # patterns to be ignored (or to be applied differently),
+      # this assertion would surface that before the warning
+      # channel stopped being relevant.
+      #
+      # When pytest-cov collects no data (which is exactly what
+      # the broken omit list causes), it skips XML emission
+      # entirely - the file simply does not exist. coverage.py
+      # 7.x prints 'No data was collected.' and pytest-cov
+      # follows up with 'Failed to generate report: No data to
+      # report.', then writes nothing. So 'no XML at all' is the
+      # primary symptom of the bug. We also accept the secondary
+      # case where some pytest-cov / coverage.py future combination
+      # might write an XML with line-rate=0 instead of skipping it,
+      # so the assertion stays robust if that behaviour changes.
+      - name: "Assert fixture reproduces the 0% coverage failure"
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ env.python_version }}
+        run: |
+          # Confirm coverage was not collected - the bug is reproduced
+          set -euo pipefail
+
+          py_xy="$(echo "${PYTHON_VERSION}" | tr -d '.')"
+          xml="/tmp/coverage-py${py_xy}/coverage.xml"
+
+          if [ ! -f "$xml" ]; then
+            echo "OK: bug reproduced - no coverage XML written ✅"
+            echo "(pytest-cov collected no data; the omit glob" \
+              "masked everything, so nothing to report)."
+            exit 0
+          fi
+
+          # XML exists - belt-and-braces check that line-rate is
+          # zero. Any value > 0 means coverage actually got
+          # measured, which would mean the omit list is no longer
+          # excluding the install location and the fixture has
+          # stopped exercising the regression.
+          python3 - "$xml" <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          xml_path = sys.argv[1]
+          root = ET.parse(xml_path).getroot()
+          rate = float(root.get('line-rate') or '0')
+          print(f'line-rate: {rate}')
+          if rate != 0.0:
+              print(
+                  f'FAIL: expected zero coverage to reproduce the '
+                  f'omit-excludes-install bug, got {rate} ❌',
+                  file=sys.stderr)
+              print(
+                  'The omit pattern no longer excludes the install '
+                  'location; either coverage.py changed pattern '
+                  'matching, or the fixture needs updating.',
+                  file=sys.stderr)
+              sys.exit(1)
+          print('OK: bug reproduced (XML exists with line-rate=0) ✅')
+          PY
+
   ### Real-world regression matrix: python-nss-ng ###
   #
   # Runs the action against the full python-nss-ng repository across

--- a/action.yaml
+++ b/action.yaml
@@ -1068,62 +1068,135 @@ runs:
           echo "Coverage collection target detected ✅" \
             "(source=${coverage_source_configured:-false}" \
             "addopts=${cov_in_addopts:-false})"
-          exit 0
-        fi
-
-        # No project-supplied target. Emit a warning to BOTH the
-        # inline console output and $GITHUB_STEP_SUMMARY so users see
-        # it without having to dig into the job log.
-        if [ -n "${coverage_fallback_pkg:-}" ]; then
-          echo "Warning: no coverage collection target configured ⚠️"
-          echo "Will use derived package name" \
-            "'${coverage_fallback_pkg}' as a best-effort fallback."
         else
-          echo "Warning: no coverage collection target configured ⚠️"
-          echo "Could not derive package name; bare '--cov' will be" \
-            "injected (may collect zero data for non-editable" \
-            "installs)."
-        fi
-        echo "Neither pytest addopts nor the coverage config sets" \
-          "a '--cov=<pkg>' or a non-empty" \
-          "'[tool.coverage.run].source' / '[coverage:run] source'."
-        echo "Configure one of the above for predictable results."
+          # No project-supplied target. Emit a warning to BOTH the
+          # inline console output and $GITHUB_STEP_SUMMARY so users see
+          # it without having to dig into the job log.
+          if [ -n "${coverage_fallback_pkg:-}" ]; then
+            echo "Warning: no coverage collection target configured ⚠️"
+            echo "Will use derived package name" \
+              "'${coverage_fallback_pkg}' as a best-effort fallback."
+          else
+            echo "Warning: no coverage collection target configured ⚠️"
+            echo "Could not derive package name; bare '--cov' will be" \
+              "injected (may collect zero data for non-editable" \
+              "installs)."
+          fi
+          echo "Neither pytest addopts nor the coverage config sets" \
+            "a '--cov=<pkg>' or a non-empty" \
+            "'[tool.coverage.run].source' / '[coverage:run] source'."
+          echo "Configure one of the above for predictable results."
 
-        if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-          {
-            echo "### ⚠️ Coverage collection target not configured"
-            echo
-            echo "Neither pytest \`addopts\` nor the coverage" \
-              "config sets a \`--cov=<pkg>\` or a non-empty" \
-              "\`[tool.coverage.run].source\` /" \
-              "\`[coverage:run] source\`."
-            echo
-            if [ -n "${coverage_fallback_pkg:-}" ]; then
-              echo "The action will pass" \
-                "\`--cov=${coverage_fallback_pkg}\` (derived from" \
-                "\`[project].name\` in \`pyproject.toml\`) as a" \
-                "best-effort fallback. For predictable results," \
-                "add one of:"
-            else
-              echo "The action will inject a bare \`--cov\` as a" \
-                "best-effort fallback (may collect zero data for" \
-                "non-editable installs). For predictable results," \
-                "add one of:"
-            fi
-            echo
-            echo "- \`--cov=<package>\` to your pytest" \
-              "\`addopts\` (in \`pyproject.toml\`," \
-              "\`pytest.ini\`, \`setup.cfg\`, or \`tox.ini\`)"
-            echo "- \`source = [\"<package>\"]\` under" \
-              "\`[tool.coverage.run]\` in \`pyproject.toml\` (or" \
-              "the equivalent INI form)"
-            echo
-            echo "Prefer the package name over a directory path" \
-              "(e.g. \`[\"mypkg\"]\`, not \`[\"src\"]\`) so that" \
-              "coverage works for both editable and non-editable" \
-              "installs."
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            {
+              echo "### ⚠️ Coverage collection target not configured"
+              echo
+              echo "Neither pytest \`addopts\` nor the coverage" \
+                "config sets a \`--cov=<pkg>\` or a non-empty" \
+                "\`[tool.coverage.run].source\` /" \
+                "\`[coverage:run] source\`."
+              echo
+              if [ -n "${coverage_fallback_pkg:-}" ]; then
+                echo "The action will pass" \
+                  "\`--cov=${coverage_fallback_pkg}\` (derived from" \
+                  "\`[project].name\` in \`pyproject.toml\`) as a" \
+                  "best-effort fallback. For predictable results," \
+                  "add one of:"
+              else
+                echo "The action will inject a bare \`--cov\` as a" \
+                  "best-effort fallback (may collect zero data for" \
+                  "non-editable installs). For predictable results," \
+                  "add one of:"
+              fi
+              echo
+              echo "- \`--cov=<package>\` to your pytest" \
+                "\`addopts\` (in \`pyproject.toml\`," \
+                "\`pytest.ini\`, \`setup.cfg\`, or \`tox.ini\`)"
+              echo "- \`source = [\"<package>\"]\` under" \
+                "\`[tool.coverage.run]\` in \`pyproject.toml\` (or" \
+                "the equivalent INI form)"
+              echo
+              echo "Prefer the package name over a directory path" \
+                "(e.g. \`[\"mypkg\"]\`, not \`[\"src\"]\`) so that" \
+                "coverage works for both editable and non-editable" \
+                "installs."
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+        fi
+
+        # Independent of the missing-target check above: even a
+        # well-configured 'source' / addopts cannot rescue coverage
+        # when the consumer's '[tool.coverage.run].omit' list
+        # explicitly excludes the directory the non-editable install
+        # lives in. setup-uv places the project under
+        # '.venv/lib/pythonX.Y/site-packages/<pkg>/', so omit globs
+        # like '*/.venv/*' or '*/site-packages/*' silently mask every
+        # measured file and produce the 'No data was collected' /
+        # 0.00% coverage failure seen in issues #138 and related
+        # downstream PRs.
+        #
+        # We only emit this warning when editable=false (the action
+        # default and the install layout that triggers the bug);
+        # editable installs put the package under the original
+        # 'src/<pkg>/' path, which the omit globs never matched in
+        # the first place.
+        if [ "${coverage_omit_excludes_install:-false}" = "true" ] \
+           && [ "${editable_lower:-false}" != "true" ]; then
+          bad_patterns="${coverage_problematic_omit_patterns:-}"
+          echo "Warning: coverage 'omit' excludes the install" \
+            "location ⚠️"
+          echo "Offending pattern(s): $bad_patterns"
+          echo "Under the action's default non-editable install," \
+            "the package lives at" \
+            ".venv/lib/pythonX.Y/site-packages/<pkg>/...; the omit" \
+            "glob(s) above match that path and coverage will" \
+            "report 0% despite tests passing."
+          echo "Remediation: remove the venv / site-packages" \
+            "entries from '[tool.coverage.run].omit' (or the" \
+            "equivalent INI form), or set the action input" \
+            "'editable: true' if you require the omit pattern."
+
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            # Re-format the ';'-joined blob from detect_coverage.py
+            # as a markdown bullet list. Each offending pattern
+            # gets its own line so users can grep step summaries
+            # for the exact value they need to remove.
+            {
+              echo "### ⚠️ Coverage \`omit\` excludes the install location"
+              echo
+              echo "The following \`[tool.coverage.run].omit\`" \
+                "pattern(s) match the directory where the action" \
+                "installs the project, causing coverage.py to" \
+                "silently exclude every measured file:"
+              echo
+              IFS=';' read -r -a _bad_arr <<< "$bad_patterns"
+              for p in "${_bad_arr[@]}"; do
+                [ -n "$p" ] && echo "- \`$p\`"
+              done
+              echo
+              echo "setup-uv places the venv at \`.venv/\` under" \
+                "the workspace root, so a non-editable install" \
+                "resolves to" \
+                "\`.venv/lib/pythonX.Y/site-packages/<pkg>/\`. Any" \
+                "omit glob containing \`venv\` or" \
+                "\`site-packages\` matches that path and produces" \
+                "the \"No data was collected\" / 0% coverage" \
+                "failure tracked in" \
+                "[lfreleng-actions/markdown-table-fixer#129](https://github.com/lfreleng-actions/markdown-table-fixer/pull/129)."
+              echo
+              echo "**Remediation (pick one):**"
+              echo
+              echo "- Remove the offending entries from" \
+                "\`[tool.coverage.run].omit\`. The remaining" \
+                "\`tests/\` / \`__pycache__/\` entries are what" \
+                "actually deserve omitting."
+              echo "- Pass \`editable: true\` to this action; the" \
+                "package then runs from its \`src/\` path and the" \
+                "omit globs no longer match."
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
         fi
 
     - name: 'Run tests and coverage report [pytest]'

--- a/scripts/detect_coverage.py
+++ b/scripts/detect_coverage.py
@@ -152,6 +152,104 @@ def has_cov_in_addopts(project: Path) -> bool:
 # --------------------------------------------------------------------------
 
 
+# Patterns that, when present in [tool.coverage.run].omit, cause
+# coverage.py to refuse to instrument the project's own code under
+# the action's default (non-editable) install layout. The package
+# physically lives at '.venv/lib/pythonX.Y/site-packages/<pkg>/...'
+# under setup-uv's workspace venv, and any omit glob matching that
+# path silently masks all collection. We match by case-insensitive
+# substring rather than parsing the glob: any literal mention of
+# 'venv' or 'site-packages' inside a pattern is sufficient evidence
+# the consumer's omit list and the action's install layout are at
+# odds. The substring approach also catches non-leading variants
+# ('.venv*', '*venv', '*/site-packages*') that a stricter
+# component-level match would miss.
+_OMIT_INSTALL_LOCATION_SUBSTRINGS: tuple[str, ...] = (
+    "venv",
+    "site-packages",
+)
+
+
+def _omit_pattern_excludes_install(pattern: str) -> bool:
+    """Return True iff a single omit glob would mask a non-editable install."""
+    lowered = pattern.lower()
+    return any(sub in lowered for sub in _OMIT_INSTALL_LOCATION_SUBSTRINGS)
+
+
+def problematic_omit_patterns(config_path: Path | None) -> list[str]:
+    """Return omit globs that exclude the non-editable install location.
+
+    Recognises:
+
+        - TOML:   [tool.coverage.run].omit                    (pyproject.toml)
+        - INI:    [coverage:run] omit                         (setup.cfg, tox.ini)
+        - INI:    [run] omit                                  (.coveragerc)
+
+    Returns the offending patterns in declaration order so the
+    action can name them explicitly in the warning it emits.
+    Returns an empty list if no coverage config is in play, the
+    file is unparsable, or every omit pattern is benign.
+
+    This is a conservative heuristic (substring match against
+    'venv' / 'site-packages'); it intentionally errs toward
+    surfacing the warning rather than silently passing a
+    misconfiguration.
+    """
+    if config_path is None or not config_path.is_file():
+        return []
+
+    suffix = config_path.suffix.lower()
+    name = config_path.name.lower()
+
+    def _filter(values: list[str]) -> list[str]:
+        return [v for v in values if _omit_pattern_excludes_install(v)]
+
+    if suffix == ".toml":
+        try:
+            with config_path.open("rb") as fh:
+                data = tomllib.load(fh)
+        except tomllib.TOMLDecodeError:
+            return []
+        omit = data.get("tool", {}).get("coverage", {}).get("run", {}).get("omit")
+        if isinstance(omit, list):
+            return _filter([item for item in omit if isinstance(item, str)])
+        if isinstance(omit, str):
+            return _filter([omit])
+        return []
+
+    # INI form: setup.cfg / tox.ini / .coveragerc.
+    cfg = configparser.ConfigParser(
+        interpolation=None,
+        inline_comment_prefixes=("#", ";"),
+    )
+    try:
+        cfg.read(config_path)
+    except configparser.Error:
+        return []
+    candidate_sections = ("coverage:run", "run")
+    if name == ".coveragerc":
+        candidate_sections = ("run", "coverage:run")
+    for section in candidate_sections:
+        if cfg.has_option(section, "omit"):
+            raw = cfg.get(section, "omit")
+            # INI multi-line values are concatenated with newlines
+            # by configparser, but consumers also occasionally
+            # paste a TOML-style single-line list directly into
+            # an INI section ('omit = ["a", "b"]'). Split on
+            # both separators and strip the punctuation noise so
+            # either spelling decomposes into one entry per
+            # pattern; commas are deliberately removed from the
+            # strip set since we already handled them as a split
+            # delimiter and dropping them again is a no-op.
+            entries: list[str] = []
+            for chunk in re.split(r"[\n,]", raw):
+                cleaned = chunk.translate(str.maketrans("", "", "[]\"'")).strip()
+                if cleaned:
+                    entries.append(cleaned)
+            return _filter(entries)
+    return []
+
+
 def has_nonempty_coverage_source(config_path: Path | None) -> bool:
     """Return True iff the discovered coverage config sets source.
 
@@ -288,6 +386,7 @@ def main(argv: list[str]) -> int:
 
     cov_in_addopts = has_cov_in_addopts(project)
     source_configured = has_nonempty_coverage_source(cov_config)
+    bad_omit_patterns = problematic_omit_patterns(cov_config)
 
     # Inject decision: ONLY suppressed by an existing --cov in
     # addopts. The source list does NOT suppress injection because
@@ -306,6 +405,15 @@ def main(argv: list[str]) -> int:
     if inject_cov and not source_configured:
         fallback_pkg = project_import_name(project)
 
+    # Persist the offending patterns as a ';'-joined string so the
+    # surrounding shell can splat them back into the warning text
+    # without having to re-parse the config. ';' is chosen because
+    # coverage.py glob syntax has no special meaning for it, and
+    # because it survives '$GITHUB_ENV' single-line writes that
+    # newlines would not.
+    omit_excludes_install = bool(bad_omit_patterns)
+    omit_patterns_blob = ";".join(bad_omit_patterns)
+
     out = (
         ("coverage_source_configured", "true" if source_configured else "false"),
         ("cov_in_addopts", "true" if cov_in_addopts else "false"),
@@ -315,6 +423,11 @@ def main(argv: list[str]) -> int:
             "true" if target_configured else "false",
         ),
         ("coverage_fallback_pkg", fallback_pkg),
+        (
+            "coverage_omit_excludes_install",
+            "true" if omit_excludes_install else "false",
+        ),
+        ("coverage_problematic_omit_patterns", omit_patterns_blob),
     )
     for key, value in out:
         print(f"{key}={value}")

--- a/tests/test_detect_coverage.py
+++ b/tests/test_detect_coverage.py
@@ -1,0 +1,491 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Unit tests for ``scripts/detect_coverage.py``.
+
+These tests run the script's public functions against the same
+``.fixtures/`` directories the end-to-end ``coverage-fixtures``
+matrix exercises, plus a handful of synthetic configs covering
+edge cases that would be expensive to encode as full action runs
+(empty source lists, INI variants, malformed TOML, ``source_pkgs``,
+nested ``omit`` patterns, etc.).
+
+The unit-test job runs orders of magnitude faster than the action
+matrix and therefore catches regressions in the detection logic
+without having to spin up a full venv for each shape. The matrix
+job remains responsible for proving the action wires the script's
+decisions into pytest-cov correctly.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+# ``detect_coverage`` lives under ``scripts/`` rather than as a
+# regular package import. Prepend the directory so the module can
+# be imported directly; this matches how the surrounding action
+# step invokes it (``python detect_coverage.py``).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import detect_coverage  # noqa: E402
+
+FIXTURES = REPO_ROOT / ".fixtures"
+
+
+# --------------------------------------------------------------------------
+# has_cov_in_addopts
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected"),
+    [
+        # Fixture matrix: each cell exercises one decision branch.
+        ("src-layout-path-source", True),  # addopts has --cov=mypkg
+        ("src-layout-pkg-source", False),  # addopts has -v only
+        ("addopts-cov-only", True),  # addopts has --cov=mypkg
+        ("flat-layout-no-config", False),  # no addopts
+        ("omit-excludes-install", True),  # addopts has --cov=mypkg
+    ],
+)
+def test_has_cov_in_addopts_against_fixtures(
+    fixture_name: str, *, expected: bool
+) -> None:
+    """Each fixture has a known addopts shape; the detector must match."""
+    assert detect_coverage.has_cov_in_addopts(FIXTURES / fixture_name) is expected
+
+
+def test_has_cov_in_addopts_distinguishes_cov_report(tmp_path: Path) -> None:
+    """``--cov-report`` shares the ``--cov`` prefix but is not a target."""
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [tool.pytest.ini_options]
+            addopts = ["-v", "--cov-report=xml", "--cov-fail-under=80"]
+            """
+        )
+    )
+    assert detect_coverage.has_cov_in_addopts(tmp_path) is False
+
+
+def test_has_cov_in_addopts_finds_bare_cov_in_string_form(tmp_path: Path) -> None:
+    """``addopts`` accepts a single string too; both shapes must be searched."""
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [tool.pytest.ini_options]
+            addopts = "-ra -q --cov --cov-report=term"
+            """
+        )
+    )
+    assert detect_coverage.has_cov_in_addopts(tmp_path) is True
+
+
+def test_has_cov_in_addopts_reads_setup_cfg(tmp_path: Path) -> None:
+    """Legacy projects that put pytest config in ``setup.cfg`` must work."""
+    (tmp_path / "setup.cfg").write_text(
+        textwrap.dedent(
+            """\
+            [tool:pytest]
+            addopts = --cov=mypkg --cov-report=term
+            """
+        )
+    )
+    assert detect_coverage.has_cov_in_addopts(tmp_path) is True
+
+
+def test_has_cov_in_addopts_ignores_comments(tmp_path: Path) -> None:
+    """A '--cov' mention inside an INI comment must not produce a match."""
+    (tmp_path / "tox.ini").write_text(
+        textwrap.dedent(
+            """\
+            [pytest]
+            # we used to pass --cov=mypkg here but removed it
+            addopts = -v -ra
+            """
+        )
+    )
+    assert detect_coverage.has_cov_in_addopts(tmp_path) is False
+
+
+# --------------------------------------------------------------------------
+# has_nonempty_coverage_source
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected"),
+    [
+        ("src-layout-path-source", True),  # source = ["src"]
+        ("src-layout-pkg-source", True),  # source = ["mypkg"]
+        ("addopts-cov-only", False),  # no [tool.coverage.run]
+        ("flat-layout-no-config", False),  # no coverage config at all
+        ("omit-excludes-install", True),  # source = ["mypkg"]
+    ],
+)
+def test_has_nonempty_coverage_source_against_fixtures(
+    fixture_name: str, *, expected: bool
+) -> None:
+    """Source detection on each fixture matches the README matrix."""
+    config = FIXTURES / fixture_name / "pyproject.toml"
+    assert detect_coverage.has_nonempty_coverage_source(config) is expected
+
+
+def test_has_nonempty_coverage_source_recognises_source_pkgs(
+    tmp_path: Path,
+) -> None:
+    """``source_pkgs`` is coverage.py's import-name-only spelling of source."""
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [tool.coverage.run]
+            source_pkgs = ["mypkg"]
+            """
+        )
+    )
+    assert (
+        detect_coverage.has_nonempty_coverage_source(tmp_path / "pyproject.toml")
+        is True
+    )
+
+
+def test_has_nonempty_coverage_source_treats_empty_list_as_unset(
+    tmp_path: Path,
+) -> None:
+    """An empty list must not count as configuration."""
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [tool.coverage.run]
+            source = []
+            """
+        )
+    )
+    assert (
+        detect_coverage.has_nonempty_coverage_source(tmp_path / "pyproject.toml")
+        is False
+    )
+
+
+def test_has_nonempty_coverage_source_handles_missing_config() -> None:
+    """A ``None`` config path must short-circuit to False without raising."""
+    assert detect_coverage.has_nonempty_coverage_source(None) is False
+
+
+def test_has_nonempty_coverage_source_reads_coveragerc(tmp_path: Path) -> None:
+    """``.coveragerc`` uses the bare ``[run]`` section name, not ``[coverage:run]``."""
+    coveragerc = tmp_path / ".coveragerc"
+    coveragerc.write_text(
+        textwrap.dedent(
+            """\
+            [run]
+            source = mypkg
+            """
+        )
+    )
+    assert detect_coverage.has_nonempty_coverage_source(coveragerc) is True
+
+
+# --------------------------------------------------------------------------
+# problematic_omit_patterns
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_patterns"),
+    [
+        # The fixtures we ship: only one has a problematic omit.
+        ("src-layout-path-source", []),
+        ("src-layout-pkg-source", []),
+        ("addopts-cov-only", []),
+        ("flat-layout-no-config", []),
+        ("omit-excludes-install", ["*/.venv/*"]),
+    ],
+)
+def test_problematic_omit_patterns_against_fixtures(
+    fixture_name: str, *, expected_patterns: list[str]
+) -> None:
+    """The omit-excludes-install fixture is the only one that should trip detection."""
+    config = FIXTURES / fixture_name / "pyproject.toml"
+    assert detect_coverage.problematic_omit_patterns(config) == expected_patterns
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "*/venv/*",
+        "*/.venv/*",
+        "*/.venv*",
+        "*venv*",
+        "*/site-packages/*",
+        "*site-packages*",
+        "*/Site-Packages/*",  # case-insensitive
+        ".VENV/lib/*",  # case-insensitive
+    ],
+)
+def test_problematic_omit_patterns_flags_install_location_globs(
+    tmp_path: Path, pattern: str
+) -> None:
+    """Each shape of install-location-matching glob must be flagged."""
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [tool.coverage.run]
+            omit = [{pattern!r}]
+            """
+        )
+    )
+    result = detect_coverage.problematic_omit_patterns(tmp_path / "pyproject.toml")
+    assert result == [pattern]
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "*/tests/*",
+        "*/test_*",
+        "*/__pycache__/*",
+        "src/mypkg/_version.py",
+        "*/.tox/*",
+    ],
+)
+def test_problematic_omit_patterns_ignores_benign_globs(
+    tmp_path: Path, pattern: str
+) -> None:
+    """Benign omit globs must not trigger a false positive."""
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [tool.coverage.run]
+            omit = [{pattern!r}]
+            """
+        )
+    )
+    assert detect_coverage.problematic_omit_patterns(tmp_path / "pyproject.toml") == []
+
+
+def test_problematic_omit_patterns_preserves_declaration_order(
+    tmp_path: Path,
+) -> None:
+    """The action emits offending patterns by name; order matters for readability."""
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [tool.coverage.run]
+            omit = [
+                "*/tests/*",
+                "*/.venv/*",
+                "*/__pycache__/*",
+                "*/site-packages/*",
+                "*/venv/*",
+            ]
+            """
+        )
+    )
+    assert detect_coverage.problematic_omit_patterns(tmp_path / "pyproject.toml") == [
+        "*/.venv/*",
+        "*/site-packages/*",
+        "*/venv/*",
+    ]
+
+
+def test_problematic_omit_patterns_reads_ini_form(tmp_path: Path) -> None:
+    """``.coveragerc`` / ``setup.cfg`` style omit lists must also be parsed."""
+    coveragerc = tmp_path / ".coveragerc"
+    coveragerc.write_text(
+        textwrap.dedent(
+            """\
+            [run]
+            omit =
+                */tests/*
+                */.venv/*
+                src/mypkg/_version.py
+            """
+        )
+    )
+    assert detect_coverage.problematic_omit_patterns(coveragerc) == ["*/.venv/*"]
+
+
+def test_problematic_omit_patterns_splits_ini_single_line_list(
+    tmp_path: Path,
+) -> None:
+    """INI sections occasionally hold a TOML-style single-line list.
+
+    A consumer copy-pasting from ``pyproject.toml`` into
+    ``setup.cfg`` can end up with
+    ``omit = ["*/.venv/*", "*/tests/*"]`` on one line.
+    configparser hands that to us verbatim; we must still split
+    on both newlines and commas so each pattern is named
+    individually in the warning the action emits.
+    """
+    setup_cfg = tmp_path / "setup.cfg"
+    setup_cfg.write_text(
+        textwrap.dedent(
+            """\
+            [coverage:run]
+            omit = ["*/.venv/*", "*/tests/*", "*/site-packages/*"]
+            """
+        )
+    )
+    assert detect_coverage.problematic_omit_patterns(setup_cfg) == [
+        "*/.venv/*",
+        "*/site-packages/*",
+    ]
+
+
+def test_problematic_omit_patterns_handles_missing_config() -> None:
+    """A ``None`` config path must short-circuit to ``[]`` without raising."""
+    assert detect_coverage.problematic_omit_patterns(None) == []
+
+
+# --------------------------------------------------------------------------
+# project_import_name
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected"),
+    [
+        # All four shipping fixtures use [project].name = "mypkg".
+        ("src-layout-path-source", "mypkg"),
+        ("src-layout-pkg-source", "mypkg"),
+        ("addopts-cov-only", "mypkg"),
+        ("flat-layout-no-config", "mypkg"),
+        ("omit-excludes-install", "mypkg"),
+    ],
+)
+def test_project_import_name_against_fixtures(
+    fixture_name: str, *, expected: str
+) -> None:
+    assert detect_coverage.project_import_name(FIXTURES / fixture_name) == expected
+
+
+@pytest.mark.parametrize(
+    ("declared", "expected"),
+    [
+        ("markdown-table-fixer", "markdown_table_fixer"),
+        ("Markdown.Table.Fixer", "markdown_table_fixer"),
+        ("My_Package", "my_package"),
+        ("dependa--merge", "dependa_merge"),
+        ("  spaced  ", "spaced"),
+    ],
+)
+def test_project_import_name_normalisation(
+    tmp_path: Path, declared: str, expected: str
+) -> None:
+    """PEP 503-style normalisation: lowercase, collapse '-/_/.' to '_'."""
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [project]
+            name = "{declared}"
+            version = "0.0.0"
+            """
+        )
+    )
+    assert detect_coverage.project_import_name(tmp_path) == expected
+
+
+def test_project_import_name_returns_empty_when_missing(tmp_path: Path) -> None:
+    """A missing or nameless pyproject.toml must yield '' rather than raising."""
+    assert detect_coverage.project_import_name(tmp_path) == ""
+    (tmp_path / "pyproject.toml").write_text("[build-system]\nrequires = []\n")
+    assert detect_coverage.project_import_name(tmp_path) == ""
+
+
+# --------------------------------------------------------------------------
+# main() end-to-end output
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def collect_output(
+    capsys: pytest.CaptureFixture[str],
+) -> Iterator["Callable[[Path, Path | None], dict[str, str]]"]:
+    """Run ``main()`` against a fixture and return the parsed KEY=VALUE output.
+
+    Reading stdout directly via ``capsys`` keeps the test coupled to
+    the surface the action.yaml step actually consumes (``while
+    read`` over the script's stdout); a mock around ``print`` would
+    drift if that contract changed.
+    """
+
+    def _run(project: Path, config: Path | None) -> dict[str, str]:
+        argv = ["detect_coverage.py", str(project)]
+        if config is not None:
+            argv.append(str(config))
+        rc = detect_coverage.main(argv)
+        assert rc == 0, f"main() returned non-zero exit code: {rc}"
+        captured = capsys.readouterr()
+        result: dict[str, str] = {}
+        for line in captured.out.splitlines():
+            if "=" in line:
+                key, _, value = line.partition("=")
+                result[key] = value
+        return result
+
+    yield _run
+
+
+def test_main_emits_all_keys_for_pkg_source_fixture(
+    collect_output: "Callable[[Path, Path | None], dict[str, str]]",
+) -> None:
+    """The shipping fixture set is the source of truth for the env-var contract."""
+    project = FIXTURES / "src-layout-pkg-source"
+    config = project / "pyproject.toml"
+    out = collect_output(project, config)
+    assert out == {
+        "coverage_source_configured": "true",
+        "cov_in_addopts": "false",
+        "coverage_inject_cov": "true",
+        "coverage_target_configured": "true",
+        "coverage_fallback_pkg": "",
+        "coverage_omit_excludes_install": "false",
+        "coverage_problematic_omit_patterns": "",
+    }
+
+
+def test_main_flags_omit_excludes_install_fixture(
+    collect_output: "Callable[[Path, Path | None], dict[str, str]]",
+) -> None:
+    """The new fixture must set both the boolean and the patterns blob."""
+    project = FIXTURES / "omit-excludes-install"
+    config = project / "pyproject.toml"
+    out = collect_output(project, config)
+    assert out["coverage_omit_excludes_install"] == "true"
+    assert out["coverage_problematic_omit_patterns"] == "*/.venv/*"
+    # The addopts '--cov=mypkg' suppresses injection but keeps the
+    # other signals at their defaults so we can be sure the omit
+    # check is the only thing that fired.
+    assert out["cov_in_addopts"] == "true"
+    assert out["coverage_inject_cov"] == "false"
+
+
+def test_main_emits_false_for_omit_signal_in_clean_fixture(
+    collect_output: "Callable[[Path, Path | None], dict[str, str]]",
+) -> None:
+    """A clean fixture must report ``false`` and an empty patterns string."""
+    project = FIXTURES / "src-layout-pkg-source"
+    config = project / "pyproject.toml"
+    out = collect_output(project, config)
+    assert out["coverage_omit_excludes_install"] == "false"
+    assert out["coverage_problematic_omit_patterns"] == ""
+
+
+def test_main_usage_error_returns_64(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing args trigger BSD ``EX_USAGE`` (64) so callers can diagnose."""
+    assert detect_coverage.main(["detect_coverage.py"]) == 64
+    err = capsys.readouterr().err
+    assert "Usage" in err


### PR DESCRIPTION
## Summary

The `No data was collected` / 0% coverage failure that broke [`lfreleng-actions/markdown-table-fixer#129`](https://github.com/lfreleng-actions/markdown-table-fixer/pull/129) was a **two-part bug**:

1. The path-based `[tool.coverage.run].source` value (already covered by the `src-layout-path-source` fixture in this repo).
2. An `omit` list containing `*/.venv/*` / `*/site-packages/*` / `*/venv/*`.

The omit half was invisible to existing detection: even a perfectly configured `source` / `addopts` cannot rescue coverage when `omit` excludes the directory the non-editable install lives in. My initial fix to `markdown-table-fixer` only changed `source` and the CI run still reported 0% — that experience drove this PR.

After scanning every Python repo under `lfreleng-actions/*`, the same omit pattern is present in **6 active projects** (`gha-workflow-linter`, `pull-request-fixer`, `project-reporting-tool`, plus 3 already-fixed-via-other-PRs cases). Adding a clear warning at the action level should head off future occurrences.

## Changes

### Detection (`scripts/detect_coverage.py`)

Conservative substring scan over `[tool.coverage.run].omit` (TOML, INI, `.coveragerc` all supported via the existing parser plumbing). A pattern containing `venv` or `site-packages` is flagged as masking the install location. The script emits two new `KEY=VALUE` pairs on stdout:

| Variable | Type | Meaning |
|---|---|---|
| `coverage_omit_excludes_install` | `true` / `false` | Boolean signal for the action to act on |
| `coverage_problematic_omit_patterns` | `;`-joined string | Offending patterns in declaration order |

### Warning (`action.yaml`)

When the boolean is `true` AND the install is non-editable, emit a warning to **both** console **and** `$GITHUB_STEP_SUMMARY`, naming each offending pattern in a markdown bullet list and pointing at the two remediation paths (fix `omit`, or pass `editable: true`). The check is independent of the existing missing-target warning; both can fire on the same project.

### New fixture (`.fixtures/omit-excludes-install/`)

Mirror of the `markdown-table-fixer` regression: correct `source = ["mypkg"]`, correct addopts `--cov=mypkg`, but `omit = ["*/tests/*", "*/.venv/*"]`. Tests pass, coverage measures 0%.

### Unit tests (`tests/test_detect_coverage.py`)

54 tests covering:
- The new omit detection (against fixtures + synthetic patterns, case-insensitive checks, INI variants, declaration-order preservation, `.coveragerc` form)
- Pre-existing `has_cov_in_addopts` / `has_nonempty_coverage_source` / `project_import_name` paths against all 5 fixtures plus synthetic edge cases (empty lists, `source_pkgs`, comment-only `--cov` mentions, string-form `addopts`, `setup.cfg`, `tox.ini`)
- `main()` end-to-end KEY=VALUE output (verifies the contract action.yaml depends on)

Pre-existing functions had no unit-test coverage before this PR; that gap is now closed.

### CI jobs (`.github/workflows/testing.yaml`)

Two new jobs alongside the existing `coverage-fixtures` matrix:

1. **`detect-coverage-unit-tests`** — runs the pytest suite above. Sub-second; provides fast feedback on detection-logic regressions without spinning up a full venv per fixture cell.
2. **`coverage-omit-warning`** — runs the action against the new fixture. Snapshots `$GITHUB_STEP_SUMMARY` size before, slices the action's contribution out of the post-action file (so other steps' summary writes can't false-pass the check), and asserts:
   - The exact warning header text appears verbatim.
   - The offending pattern (`*/.venv/*`) is rendered as a markdown bullet.
   - Coverage XML `line-rate` is **zero** (locks in that the fixture really does reproduce the regression — a future change that silently "fixed" omit handling would be caught here too).

### Docs (`.fixtures/README.md`)

Updated decision matrix, fixture table, "why this matters" entry for the new fixture.

## Verification

Locally (against the new fixture):

| Check | Result |
|---|---|
| All 54 unit tests | ✅ pass in 0.05s |
| `detect_coverage.py` against `omit-excludes-install` | `coverage_omit_excludes_install=true`, `coverage_problematic_omit_patterns=*/.venv/*` |
| `detect_coverage.py` against `src-layout-pkg-source` (clean) | `coverage_omit_excludes_install=false` |
| `pytest` against new fixture (simulating action) | `2 passed`, `WARNING: Failed to generate report: No data to report` (bug reproduced) |
| `actionlint` on `testing.yaml` | clean |
| `python -c yaml.safe_load(...)` on both `.yaml` files | clean |