### PR TITLE
CI(testing): Disambiguate build artefact per matrix leg

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -78,6 +78,10 @@ jobs:
         with:
           path_prefix: "test-python-project"
           tox_build: false
+          # Disambiguate artefact names across matrix legs (ubuntu-24.04
+          # and ubuntu-24.04-arm) to avoid actions/upload-artifact 409
+          # Conflict errors when both legs upload concurrently.
+          artefact_name: "lfreleng-test-python-project-${{ matrix.runs-on }}"
 
       # Perform Python project standard tests
       - name: "Run action: ${{ github.repository }} [PYTEST]"


### PR DESCRIPTION
## Summary

Fixes intermittent `(409) Conflict: an artifact with this name already exists on the workflow run` failures in the `standard-tests` matrix job.

Most recently observed on the unrelated dependabot PR #146 (`test-python-project (ubuntu-24.04-arm)`):
https://github.com/lfreleng-actions/python-test-action/actions/runs/25733962951/job/75565945368

## Root cause

The `standard-tests` matrix runs on `ubuntu-24.04` and `ubuntu-24.04-arm` and invokes `python-build-action` **without** an explicit `artefact_name`:

```yaml
      - name: "Build Python project"
        uses: lfreleng-actions/python-build-action@…
        with:
          path_prefix: "test-python-project"
          tox_build: false
```

Both legs therefore default to the same upload name derived from project metadata (`lfreleng-test-python-project`). Whichever leg finishes uploading second hits a 409 from `actions/upload-artifact`. The race is timing-dependent, so the failure is intermittent rather than deterministic — which is why it surfaced on a tiny dependabot PR but not on larger PRs whose timings happened to interleave differently.

## Fix

Pass `artefact_name` suffixed with `matrix.runs-on`, giving each matrix leg a unique upload name. This mirrors the established pattern in:

- **`python-build-action`'s own `test-multi-arch-projects` job**, which carries the comment _"Disambiguate artefact names across architectures to avoid upload-artifact 409 Conflict errors"_.
- **`python-nss-ng`'s `build-test-release.yaml`**, which uses `python-nss-ng-x64-py…` / `python-nss-ng-arm64-py…` per leg.

`python-build-action`'s `artefact_name` input has always been documented for exactly this case ("Useful when building for multiple platforms/architectures / Can be used to avoid uploading artefacts with conflicting names"), so no upstream action change is required.

## Verification

- `yamllint`, `actionlint`, and the workflow-validation pre-commit hooks all pass locally.
- The change is scoped to a single `with:` block in `.github/workflows/testing.yaml`; no production action behaviour changes.